### PR TITLE
Incorrect usage of _.omit

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -12,7 +12,7 @@ const winstonLogger = new winston.Logger({
   rewriters: [
     (level: string, message: string, meta: Object): Object => (
       _.isEmpty(meta.tags)
-        ? _.omit(['tags'], meta)
+        ? _.omit(meta, ['tags'])
         : meta
     ),
   ],


### PR DESCRIPTION
https://lodash.com/docs/#omit
```
var object = { 'a': 1, 'b': '2', 'c': 3 };
 
_.omit(object, ['a', 'c']);
// => { 'b': '2' }
```